### PR TITLE
use anchor for parsing origin url because IE

### DIFF
--- a/csrf.coffee
+++ b/csrf.coffee
@@ -60,8 +60,11 @@ $(document).on 'submit:prepare', 'form', ->
 
   return
 
+origin = document.createElement 'a'
+origin.href = location.href
+
 # Check if url is within the same origin policy.
 isSameOrigin = (url) ->
   a = document.createElement 'a'
   a.href = url
-  "#{location.protocol}//#{location.host}" == "#{a.protocol}//#{a.host}"
+  "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"

--- a/csrf.coffee
+++ b/csrf.coffee
@@ -67,4 +67,5 @@ origin.href = location.href
 isSameOrigin = (url) ->
   a = document.createElement 'a'
   a.href = url
+  a.href = a.href
   "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"


### PR DESCRIPTION
Fixes an IE specific issue introduced in https://github.com/josh/rails-behaviors/pull/40.