### PR TITLE
Make sure that browser is parsing urls correctly

### DIFF
--- a/csrf.coffee
+++ b/csrf.coffee
@@ -60,17 +60,14 @@ $(document).on 'submit:prepare', 'form', ->
 
   return
 
-origin = document.createElement 'a'
-origin.href = location.href
+originUrl = new URL(location.href)
 
 # Check if url is within the same origin policy.
-isSameOrigin = (url) ->
-  a = document.createElement 'a'
-  a.href = url
-  a.href = a.href
+isSameOrigin = (urlString) ->
+  url = new URL(urlString, originUrl)
 
   # Make sure that the browser parses the URL.
-  a.protocol && a.host &&
+  url.origin && url.origin != "null" &&
 
   # Make sure that the protocols and hosts match.
-  "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"
+  originUrl.origin == url.origin

--- a/csrf.coffee
+++ b/csrf.coffee
@@ -60,14 +60,17 @@ $(document).on 'submit:prepare', 'form', ->
 
   return
 
-originUrl = new URL(location.href)
+origin = document.createElement 'a'
+origin.href = location.href
 
 # Check if url is within the same origin policy.
-isSameOrigin = (urlString) ->
-  url = new URL(urlString, originUrl)
+isSameOrigin = (url) ->
+  a = document.createElement 'a'
+  a.href = url
+  a.href = a.href
 
   # Make sure that the browser parses the URL.
-  url.origin && url.origin != "null" &&
+  a.protocol && a.host &&
 
   # Make sure that the protocols and hosts match.
-  originUrl.origin == url.origin
+  "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"

--- a/csrf.coffee
+++ b/csrf.coffee
@@ -69,11 +69,8 @@ isSameOrigin = (url) ->
   a.href = url
   a.href = a.href
 
-  # Make sure that the browser parses out a protocol.
-  a.protocol && origin.protocol &&
-
-  # Make sure that the browser parses out host.
-  a.host && origin.host &&
+  # Make sure that the browser parses the URL.
+  a.protocol && a.host &&
 
   # Make sure that the protocols and hosts match.
   "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"

--- a/csrf.coffee
+++ b/csrf.coffee
@@ -68,4 +68,12 @@ isSameOrigin = (url) ->
   a = document.createElement 'a'
   a.href = url
   a.href = a.href
+
+  # Make sure that the browser parses out a protocol.
+  a.protocol && origin.protocol && a.protocol != "" && origin.protocol != "" &&
+
+  # Make sure that the browser parses out host.
+  a.host && origin.host && a.host != "" && origin.host != "" &&
+
+  # Make sure that the protocols and hosts match.
   "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"

--- a/csrf.coffee
+++ b/csrf.coffee
@@ -70,10 +70,10 @@ isSameOrigin = (url) ->
   a.href = a.href
 
   # Make sure that the browser parses out a protocol.
-  a.protocol && origin.protocol && a.protocol != "" && origin.protocol != "" &&
+  a.protocol && origin.protocol &&
 
   # Make sure that the browser parses out host.
-  a.host && origin.host && a.host != "" && origin.host != "" &&
+  a.host && origin.host &&
 
   # Make sure that the protocols and hosts match.
   "#{origin.protocol}//#{origin.host}" == "#{a.protocol}//#{a.host}"


### PR DESCRIPTION
There is a bug where some browser will return a `""` host for a malformed URL. This PR ensures that the URL is actually parsed.

/cc @josh @mislav @ptoomey3 @gregose @oreoshake @ealf